### PR TITLE
Add a categories list module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "contao/core-bundle": "^4.13",
         "contao/calendar-bundle": "^4.13",
         "doctrine/dbal": "^3.0",
-        "codefog/contao-haste": "^4.25 || ^5.0"
+        "codefog/contao-haste": "^4.25 || ^5.0",
+        "nyholm/psr7": "^1.8"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0"
@@ -48,5 +49,12 @@
     },
     "scripts": {
         "cs-fixer": "@php tools/ecs/vendor/bin/ecs check src/ --config tools/ecs/config.php --fix --ansi"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false,
+            "contao-components/installer": true,
+            "contao/manager-plugin": true
+        }
     }
 }

--- a/contao/dca/tl_module.php
+++ b/contao/dca/tl_module.php
@@ -1,9 +1,11 @@
 <?php
 
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
+use Terminal42\CalendarCategoriesBundle\Controller\FrontendModule\CalendarCategoriesListController;
 
 PaletteManipulator::create()
-    ->addField('cal_categories', 'cal_calendar')
+    ->addField('cal_categories', 'config_legend', PaletteManipulator::POSITION_APPEND)
+    ->addField('cal_categoriesFilter', 'config_legend', PaletteManipulator::POSITION_APPEND)
     ->applyToPalette('eventlist', 'tl_module')
 ;
 
@@ -14,3 +16,27 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['cal_categories'] = [
     'sql' => ['type' => 'blob', 'notnull' => false],
     'relation' => ['type' => 'lazy', 'table' => 'tl_calendar_category'],
 ];
+
+$GLOBALS['TL_DCA']['tl_module']['fields']['cal_categoriesRoot'] = [
+    'exclude' => true,
+    'inputType' => 'picker',
+    'eval' => ['fieldType' => 'radio', 'tl_class' => 'clr'],
+    'sql' => ['type' => 'integer', 'unsigned' => true, 'default' => 0],
+    'relation' => ['type' => 'lazy', 'table' => 'tl_calendar_category'],
+];
+
+$GLOBALS['TL_DCA']['tl_module']['fields']['cal_categoriesReset'] = [
+    'exclude' => true,
+    'inputType' => 'checkbox',
+    'eval' => ['tl_class' => 'w50 m12'],
+    'sql' => ['type' => 'boolean', 'default' => false],
+];
+
+$GLOBALS['TL_DCA']['tl_module']['fields']['cal_categoriesFilter'] = [
+    'exclude' => true,
+    'inputType' => 'checkbox',
+    'eval' => ['tl_class' => 'w50'],
+    'sql' => ['type' => 'boolean', 'default' => false],
+];
+
+$GLOBALS['TL_DCA']['tl_module']['palettes'][CalendarCategoriesListController::TYPE] = '{title_legend},name,headline,type;{config_legend},cal_categoriesRoot,showLevel,cal_categoriesReset;{redirect_legend},jumpT;{template_legend:hide},customTpl,navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID';

--- a/contao/dca/tl_module.php
+++ b/contao/dca/tl_module.php
@@ -39,4 +39,4 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['cal_categoriesFilter'] = [
     'sql' => ['type' => 'boolean', 'default' => false],
 ];
 
-$GLOBALS['TL_DCA']['tl_module']['palettes'][CalendarCategoriesListController::TYPE] = '{title_legend},name,headline,type;{config_legend},cal_categoriesRoot,showLevel,cal_categoriesReset;{redirect_legend},jumpT;{template_legend:hide},customTpl,navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID';
+$GLOBALS['TL_DCA']['tl_module']['palettes'][CalendarCategoriesListController::TYPE] = '{title_legend},name,headline,type;{config_legend},cal_categoriesRoot,showLevel,cal_categoriesReset;{redirect_legend},jumpTo;{template_legend:hide},customTpl,navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID';

--- a/contao/languages/de/modules.php
+++ b/contao/languages/de/modules.php
@@ -1,0 +1,5 @@
+<?php
+
+use Terminal42\CalendarCategoriesBundle\Controller\FrontendModule\CalendarCategoriesListController;
+
+$GLOBALS['TL_LANG']['FMD'][CalendarCategoriesListController::TYPE] = ['Kategorie-Liste', 'Stelle eine Filtermöglichkeit anhand der Kalender-Kategorien zur Verfügung.'];

--- a/contao/languages/de/tl_module.php
+++ b/contao/languages/de/tl_module.php
@@ -1,3 +1,6 @@
 <?php
 
 $GLOBALS['TL_LANG']['tl_module']['cal_categories'] = ['Kalender-Kategorien', 'Wählen Sie Kategorien um die Eventliste einzuschränken.'];
+$GLOBALS['TL_LANG']['tl_module']['cal_categoriesRoot'] = ['Referenz-Kategorie', 'Hier kann die Referenzkategorie ausgewählt werden. Diese wird als Startpunkt benutzt.'];
+$GLOBALS['TL_LANG']['tl_module']['cal_categoriesReset'] = ['Kategorie-Filter zurücksetzen', 'Fügt einen Link hinzu, um die Filter zurückzusetzen.'];
+$GLOBALS['TL_LANG']['tl_module']['cal_categoriesFilter'] = ['Nach Kategorien filtern', 'Filtert die Event-Liste nach Kategorien.'];

--- a/contao/languages/en/modules.php
+++ b/contao/languages/en/modules.php
@@ -1,0 +1,5 @@
+<?php
+
+use Terminal42\CalendarCategoriesBundle\Controller\FrontendModule\CalendarCategoriesListController;
+
+$GLOBALS['TL_LANG']['FMD'][CalendarCategoriesListController::TYPE] = ['Categories list', 'Lists calendar categories, providing a filter menu.'];

--- a/contao/languages/en/tl_module.php
+++ b/contao/languages/en/tl_module.php
@@ -1,3 +1,6 @@
 <?php
 
 $GLOBALS['TL_LANG']['tl_module']['cal_categories'] = ['Calendar categories', 'Choose the calendar categories to filter the event list.'];
+$GLOBALS['TL_LANG']['tl_module']['cal_categoriesRoot'] = ['Root category', 'Choose an optional root category for the list module.'];
+$GLOBALS['TL_LANG']['tl_module']['cal_categoriesReset'] = ['Add reset', 'Adds a reset link to the list module.'];
+$GLOBALS['TL_LANG']['tl_module']['cal_categoriesFilter'] = ['Filter by categories', 'Filter the event list by the categories list module.'];

--- a/contao/templates/mod_calendar_categories_list.html5
+++ b/contao/templates/mod_calendar_categories_list.html5
@@ -1,0 +1,5 @@
+<?php $this->extend('block_unsearchable'); ?>
+
+<?php $this->block('content'); ?>
+  <?= $this->categories ?>
+<?php $this->endblock(); ?>

--- a/src/Controller/ContentElement/EventlistController.php
+++ b/src/Controller/ContentElement/EventlistController.php
@@ -21,7 +21,7 @@ class EventlistController
     {
         $moduleModel = ModuleModel::findByPk($model->module);
 
-        if (null === $moduleModel || $moduleModel->type !== 'eventlist') {
+        if (null === $moduleModel || 'eventlist' !== $moduleModel->type) {
             return new Response();
         }
 

--- a/src/Controller/ContentElement/EventlistController.php
+++ b/src/Controller/ContentElement/EventlistController.php
@@ -21,7 +21,7 @@ class EventlistController
     {
         $moduleModel = ModuleModel::findByPk($model->module);
 
-        if (null === $moduleModel || 'eventlist' !== $moduleModel->type) {
+        if (null === $moduleModel || $moduleModel->type !== 'eventlist') {
             return new Response();
         }
 

--- a/src/Controller/FrontendModule/CalendarCategoriesListController.php
+++ b/src/Controller/FrontendModule/CalendarCategoriesListController.php
@@ -73,7 +73,7 @@ class CalendarCategoriesListController extends AbstractFrontendModuleController
                 'link' => StringUtil::specialchars($resetLabel),
                 'isActive' => null === $request->query->get(self::PARAM_NAME),
                 'href' => StringUtil::specialcharsUrl($uri->withQuery(http_build_query($query))),
-                'class' => 'reset',
+                'class' => 'reset'.(null === $request->query->get(self::PARAM_NAME) ? ' active' : ''),
                 'accesskey' => '',
                 'tabindex' => '',
                 'target' => '',
@@ -88,7 +88,7 @@ class CalendarCategoriesListController extends AbstractFrontendModuleController
             $item['pageTitle'] = null;
             $item['link'] = StringUtil::specialchars($category->name);
             $item['isActive'] = (int) $category->id === (int) $request->query->get(self::PARAM_NAME);
-            $item['class'] = 'category';
+            $item['class'] = 'category'.($item['isActive'] ? ' active' : '');
             $item['accesskey'] = '';
             $item['tabindex'] = '';
             $item['target'] = '';

--- a/src/Controller/FrontendModule/CalendarCategoriesListController.php
+++ b/src/Controller/FrontendModule/CalendarCategoriesListController.php
@@ -59,7 +59,7 @@ class CalendarCategoriesListController extends AbstractFrontendModuleController
             $uri = new Uri($jumpTo->getAbsoluteUrl());
         } else {
             $uri = new Uri($request->getUri());
-            parse_str($uri->getQuery(), $query);
+            $query = $request->query->all();
         }
 
         if (1 === $level && $model->cal_categoriesReset) {

--- a/src/Controller/FrontendModule/CalendarCategoriesListController.php
+++ b/src/Controller/FrontendModule/CalendarCategoriesListController.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\CalendarCategoriesBundle\Controller\FrontendModule;
+
+use Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController;
+use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
+use Contao\FrontendTemplate;
+use Contao\ModuleModel;
+use Contao\PageModel;
+use Contao\StringUtil;
+use Contao\Template;
+use Nyholm\Psr7\Uri;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Terminal42\CalendarCategoriesBundle\Model\CalendarCategoryModel;
+
+/**
+ * @FrontendModule(category="events", type=self::TYPE, template="mod_calendar_categories_list")
+ */
+class CalendarCategoriesListController extends AbstractFrontendModuleController
+{
+    public const TYPE = 'calendar_categories_list';
+    public const PARAM_NAME = 'category';
+
+    private TranslatorInterface $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    protected function getResponse(Template $template, ModuleModel $model, Request $request): Response
+    {
+        $template->categories = $this->renderCategories((int) $model->cal_categoriesRoot, $model, $request);
+
+        return $template->getResponse();
+    }
+
+    private function renderCategories(int $pid, ModuleModel $model, Request $request, int $level = 1): string
+    {
+        $categories = CalendarCategoryModel::findBy(['pid = ?'], [$pid], ['order' => 'sorting ASC']);
+
+        if (null === $categories) {
+            return '';
+        }
+
+        $template = new FrontendTemplate($model->navigationTpl ?: 'nav_default');
+        $template->pid = $pid;
+        $template->type = static::class;
+        $template->level = 'level_'.$level;
+
+        $items = [];
+        $query = [];
+
+        if ($jumpTo = PageModel::findById($model->jumpTo)) {
+            $uri = new Uri($jumpTo->getAbsoluteUrl());
+        } else {
+            $uri = new Uri($request->getUri());
+            parse_str($uri->getQuery(), $query);
+        }
+
+        if (1 === $level && $model->cal_categoriesReset) {
+            $resetLabel = $this->translator->trans('categories_list_reset.label', [], 'calendar_categories');
+            $resetTitle = $this->translator->trans('categories_list_reset.title', [], 'calendar_categories');
+            unset($query[self::PARAM_NAME]);
+
+            $items[] = [
+                'pageTitle' => null,
+                'title' => StringUtil::specialcharsAttribute($resetTitle),
+                'link' => StringUtil::specialchars($resetLabel),
+                'isActive' => null === $request->query->get(self::PARAM_NAME),
+                'href' => StringUtil::specialcharsUrl($uri->withQuery(http_build_query($query))),
+                'class' => 'reset',
+                'accesskey' => '',
+                'tabindex' => '',
+                'target' => '',
+            ];
+        }
+
+        ++$level;
+
+        foreach ($categories as $category) {
+            $item = $category->row();
+            $item['title'] = StringUtil::specialcharsAttribute($category->name);
+            $item['pageTitle'] = null;
+            $item['link'] = StringUtil::specialchars($category->name);
+            $item['isActive'] = (int) $category->id === (int) $request->query->get(self::PARAM_NAME);
+            $item['class'] = 'category';
+            $item['accesskey'] = '';
+            $item['tabindex'] = '';
+            $item['target'] = '';
+
+            if (!$model->showLevel || $model->showLevel >= $level) {
+                $item['subitems'] = $this->renderCategories((int) $category->id, $model, $request, $level);
+            }
+
+            $query[self::PARAM_NAME] = (int) $category->id;
+            $item['href'] = StringUtil::specialcharsUrl($uri->withQuery(http_build_query($query)));
+
+            $items[] = $item;
+        }
+
+        $template->items = $items;
+
+        return $template->parse();
+    }
+}

--- a/src/Controller/FrontendModule/CalendarCategoriesListController.php
+++ b/src/Controller/FrontendModule/CalendarCategoriesListController.php
@@ -65,15 +65,16 @@ class CalendarCategoriesListController extends AbstractFrontendModuleController
         if (1 === $level && $model->cal_categoriesReset) {
             $resetLabel = $this->translator->trans('categories_list_reset.label', [], 'calendar_categories');
             $resetTitle = $this->translator->trans('categories_list_reset.title', [], 'calendar_categories');
+            $resetActive = null === $request->query->get(self::PARAM_NAME);
             unset($query[self::PARAM_NAME]);
 
             $items[] = [
                 'pageTitle' => null,
                 'title' => StringUtil::specialcharsAttribute($resetTitle),
                 'link' => StringUtil::specialchars($resetLabel),
-                'isActive' => null === $request->query->get(self::PARAM_NAME),
+                'isActive' => $resetActive,
                 'href' => StringUtil::specialcharsUrl($uri->withQuery(http_build_query($query))),
-                'class' => 'reset'.(null === $request->query->get(self::PARAM_NAME) ? ' active' : ''),
+                'class' => 'reset'.($resetActive ? ' active' : ''),
                 'accesskey' => '',
                 'tabindex' => '',
                 'target' => '',

--- a/translations/calendar_categories.de.yaml
+++ b/translations/calendar_categories.de.yaml
@@ -1,0 +1,3 @@
+categories_list_reset:
+  label: Alle Kategorien
+  title: Zeige die Events aller Kategorien

--- a/translations/calendar_categories.en.yaml
+++ b/translations/calendar_categories.en.yaml
@@ -1,0 +1,3 @@
+categories_list_reset:
+  label: All categories
+  title: Show events from all categories


### PR DESCRIPTION
Fixes #4

This adds a very simple categories list module, so that you can filter an event list by categories via a `category` query parameter.

This can be expanded on in future versions, to provide similar functionalities like in `codefog/contao-news_categories`:

* Provide cumulative filtering.
* Being able to rename the filter parameter name (currently hardcoded as `category`).
* Not showing empty categories (might be difficult, due to repeating events).
* …

For this PR I wanted to only provide an MVP.