### PR TITLE
Contao 5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,14 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "contao/core-bundle": "^4.13",
-        "contao/calendar-bundle": "^4.13",
+        "contao/core-bundle": "^4.13 || ^5.3",
+        "contao/calendar-bundle": "^4.13 || ^5.3",
         "doctrine/dbal": "^3.0",
-        "codefog/contao-haste": "^4.25 || ^5.0"
+        "codefog/contao-haste": "^4.25 || ^5.0",
+		"symfony/config": "^5.0 || ^6.0 || ^7.0",
+		"symfony/dependency-injection": "^5.0 || ^6.0 || ^7.0",
+		"symfony/http-foundation": "^5.0 || ^6.0 || ^7.0",
+		"symfony/http-kernel": "^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0"

--- a/contao/dca/tl_calendar_category.php
+++ b/contao/dca/tl_calendar_category.php
@@ -1,12 +1,14 @@
 <?php
 
+use Contao\DC_Table;
+
 \Contao\System::loadLanguageFile('tl_calendar');
 
 $GLOBALS['TL_DCA']['tl_calendar_category'] = [
     // Config
     'config' => [
         'label' => $GLOBALS['TL_LANG']['tl_calendar']['categories'][0],
-        'dataContainer' => 'Table',
+        'dataContainer' => DC_Table::class,
         'enableVersioning' => true,
         'backlink' => 'do=calendar',
         'markAsCopy' => 'name',
@@ -24,6 +26,7 @@ $GLOBALS['TL_DCA']['tl_calendar_category'] = [
             'mode' => 5,
             'icon' => 'bundles/terminal42calendarcategories/icon.png',
             'panelLayout' => 'search',
+			'rootPaste' => true,
         ],
         'label' => [
             'fields' => ['name'],

--- a/contao/languages/de/tl_calendar_category.php
+++ b/contao/languages/de/tl_calendar_category.php
@@ -2,3 +2,5 @@
 
 $GLOBALS['TL_LANG']['tl_calendar_category']['name'] = ['Name', 'Geben Sie den Namen der Kategorie ein.'];
 $GLOBALS['TL_LANG']['tl_calendar_category']['name_legend'] = 'Name';
+
+$GLOBALS['TL_LANG']['tl_calendar_category']['copyChilds'] = 'Element ID %s inklusive Kindelemente duplizieren';

--- a/contao/languages/en/tl_calendar_category.php
+++ b/contao/languages/en/tl_calendar_category.php
@@ -2,3 +2,5 @@
 
 $GLOBALS['TL_LANG']['tl_calendar_category']['name'] = ['Name', 'Please enter the category name.'];
 $GLOBALS['TL_LANG']['tl_calendar_category']['name_legend'] = 'Name';
+
+$GLOBALS['TL_LANG']['tl_calendar_category']['copyChilds'] = 'Duplicate element ID %s including child elements';


### PR DESCRIPTION
This PR adds compatibility for Contao 5.3+, tested on 5.3.x-dev and 5.x-dev.
Also still compatible with 4.13.