### PR TITLE
Add cal_categories also to calendar palette in tl_module

### DIFF
--- a/contao/dca/tl_module.php
+++ b/contao/dca/tl_module.php
@@ -4,6 +4,7 @@ use Contao\CoreBundle\DataContainer\PaletteManipulator;
 
 PaletteManipulator::create()
     ->addField('cal_categories', 'cal_calendar')
+    ->applyToPalette('calendar', 'tl_module')
     ->applyToPalette('eventlist', 'tl_module')
 ;
 


### PR DESCRIPTION
Allows you to set categories for the calendar module.
When #5 is merged, filtering via the URL parameter is also possible in the calendar :)